### PR TITLE
Add meeting notes for backend meeting on Nov 22, 2025

### DIFF
--- a/meetingLOG.md
+++ b/meetingLOG.md
@@ -1,0 +1,21 @@
+## Backend Meeting - November 22, 2025
+## Attendees
+Moustafa, Abdulrahmansoliman, Hectar
+
+# Agenda
+Review current backend architecture
+Discuss repository pattern implementation
+Plan rotation city API endpoint
+
+# Discussion Points
+Repository Pattern Design
+Reviewed repository pattern example from commit 46a0982
+Current implementation uses static methods with tight coupling to ORM
+Agreed this approach limits testability and violates SOLID principles
+Decision: Adopt repository pattern with abstract interfaces and concrete implementations
+
+# Architecture Agreement
+Create abstract repository interfaces using Python ABC
+Implement concrete repositories with SQLAlchemy
+Use dependency injection in services
+Enable proper unit testing with mocked dependencies


### PR DESCRIPTION
Documented the backend meeting held on November 22, 2025, including attendees, agenda, discussion points, and architectural agreements.