### PR TITLE
feat: Make CORS origins configurable via environment variable

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,6 +1,8 @@
 from flask import Flask
 from flask_sqlalchemy import SQLAlchemy
 from flask_jwt_extended import JWTManager
+from flask_cors import CORS
+import os
 
 db = SQLAlchemy()
 jwt = JWTManager()
@@ -25,6 +27,18 @@ def create_app(config_name='development'):
     # Initialize extensions
     db.init_app(app)
     jwt.init_app(app)
+    
+    # Enable CORS with configurable origins
+    cors_origins = os.getenv('CORS_ORIGINS', 'http://localhost:5173').split(',')
+    
+    CORS(app, resources={
+        r"/api/*": {
+            "origins": cors_origins,
+            "methods": ["GET", "POST", "PUT", "DELETE", "OPTIONS"],
+            "allow_headers": ["Content-Type", "Authorization"],
+            "supports_credentials": True
+        }
+    })
     
     # Register blueprints and JWT handlers
     from app.api.v1 import api_bp

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -3,6 +3,7 @@ Flask-SQLAlchemy==3.1.1
 SQLAlchemy==2.0.23
 pydantic==2.5.0
 Flask-JWT-Extended==4.6.0
+Flask-CORS==4.0.0
 
 # Testing
 pytest==7.4.3


### PR DESCRIPTION
**Configurable CORS Origins** - Environment variable-based configuration for cross-origin requests


CORS Configuration
- **Feature:** CORS origins now configurable via `CORS_ORIGINS` environment variable
- **Default:** `http://localhost:5173` (Vite dev server)
- **Usage Examples:**
  ```bash
  # Development (uses default)
  python run.py
  
  # Production with custom origins
  export CORS_ORIGINS=https://yourdomain.com,https://www.yourdomain.com
  python run.py