### PR TITLE
fix: Resolve 6 failing tests - all tests now passing

### DIFF
--- a/backend/app/api/v1/schemas/item_schema.py
+++ b/backend/app/api/v1/schemas/item_schema.py
@@ -28,9 +28,9 @@ class UserNested(BaseModel):
 class CategoryNested(BaseModel):
     """Nested category in item response."""
     category_id: int
-    name: str
+    name: str = Field(alias='category_name')
     
-    model_config = ConfigDict(from_attributes=True)
+    model_config = ConfigDict(from_attributes=True, populate_by_name=True)
 
 
 class TagWithValue(BaseModel):

--- a/backend/app/services/item_service.py
+++ b/backend/app/services/item_service.py
@@ -231,15 +231,16 @@ class ItemService:
                 tag_dict = {
                     'tag_id': itv.value.tag.tag_id,
                     'name': itv.value.tag.name,
-                    'value_type': itv.value.tag.value_type,
+                    'value_type': itv.value.tag.value_type_label,
                 }
                 
                 # Get the actual value based on value_type (using correct field names)
-                if itv.value.tag.value_type == 'boolean':
+                value_type_label = itv.value.tag.value_type_label
+                if value_type_label == 'boolean':
                     tag_dict['value'] = itv.value.boolean_val
-                elif itv.value.tag.value_type == 'text':
+                elif value_type_label == 'text':
                     tag_dict['value'] = itv.value.name_val
-                elif itv.value.tag.value_type == 'numeric':
+                elif value_type_label == 'numeric':
                     tag_dict['value'] = itv.value.numerical_value
                 
                 tags.append(tag_dict)

--- a/backend/tests/integration/test_item_routes.py
+++ b/backend/tests/integration/test_item_routes.py
@@ -344,8 +344,8 @@ class TestItemRoutes:
         headers = {'Authorization': f'Bearer {tokens["access_token"]}'}
         
         # Create categories
-        category1 = Category(name="Electronics")
-        category2 = Category(name="Furniture")
+        category1 = Category(category_name="Electronics")
+        category2 = Category(category_name="Furniture")
         db.session.add_all([category1, category2])
         db.session.commit()
         
@@ -392,7 +392,7 @@ class TestItemRoutes:
         headers = {'Authorization': f'Bearer {tokens["access_token"]}'}
         
         # Create category and item
-        category = Category(name="Books")
+        category = Category(category_name="Books")
         db.session.add(category)
         db.session.commit()
         


### PR DESCRIPTION
Fix failing integration tests caused by mismatches between the refactored `Category` model and Item API responses. Updates include adding field aliases and config tweaks in `item_schema.py`, correcting value-type handling in `item_service.py`, and aligning test constructors in `test_item_routes.py`. All tests now pass (257/257).
