### PR TITLE
feat: add profile_picture to user model/repo/schema

### DIFF
--- a/backend/app/api/v1/auth/register.py
+++ b/backend/app/api/v1/auth/register.py
@@ -20,6 +20,7 @@ def register():
         city_id (int): ID of user's current rotation city
         first_name (str): User's first name
         last_name (str): User's last name
+        profile_picture (str, optional): Base64 encoded profile picture
         
     Returns:
         201: User registered successfully, verification email sent
@@ -35,13 +36,16 @@ def register():
     first_name = data['first_name']
     last_name = data['last_name']
 
+    profile_picture = data.get('profile_picture', None)
+
     try:
         registration_service = RegistrationService()
         new_user = registration_service.register_user(
             first_name=first_name,
             last_name=last_name,
             email=email,
-            rotation_city_id=city_id
+            rotation_city_id=city_id,
+            profile_picture=profile_picture
         )
         if new_user is None:
             return jsonify({'message': 'Verification code resent. Please check your email.'}), 200

--- a/backend/app/api/v1/schemas/user_schema.py
+++ b/backend/app/api/v1/schemas/user_schema.py
@@ -8,6 +8,7 @@ class UserResponse(BaseModel):
     first_name: str
     last_name: str
     email: str | None = None
+    profile_picture: str | None = None
     rotation_city: RotationCityResponse | None = None
 
     model_config = ConfigDict(from_attributes=True)

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -4,7 +4,7 @@ Represents a user in the system. Each user belongs to a rotation city
 and can add/verify items.
 """
 from datetime import datetime
-from sqlalchemy import Column, DateTime, ForeignKey, Integer, String, Boolean
+from sqlalchemy import Column, DateTime, ForeignKey, Integer, String, Boolean, Text
 from sqlalchemy.orm import relationship
 from app.models.verification_stutus_enum import VerificationStatusEnum
 
@@ -23,6 +23,7 @@ class User(db.Model):
         first_name (str): User's first name (max 50 chars)
         last_name (str): User's last name (max 50 chars)
         email (str): Unique email address (max 100 chars)
+        profile_picture (str): Optional profile picture as base64 string
         created_at (datetime): Account creation timestamp
         updated_at (datetime): Last update timestamp
         is_verified (bool): Email verification status
@@ -48,6 +49,8 @@ class User(db.Model):
     first_name = Column(String(50), nullable=False)
     last_name = Column(String(50), nullable=False)
     email = Column(String(100), unique=True, nullable=False)
+    # Optional profile picture stored as base64 for simplicity
+    profile_picture = Column(Text, nullable=True)
     
     # Timestamps
     created_at = Column(DateTime, default=datetime.utcnow)

--- a/backend/app/repositories/base/user_repository_interface.py
+++ b/backend/app/repositories/base/user_repository_interface.py
@@ -15,7 +15,8 @@ class IUserRepository(ABC):
         first_name: str,
         last_name: str,
         email: str,
-        rotation_city_id: int
+        rotation_city_id: int,
+        profile_picture: Optional[str] = None,
     ) -> User:
         pass
     

--- a/backend/app/repositories/implementations/user_repository.py
+++ b/backend/app/repositories/implementations/user_repository.py
@@ -31,7 +31,8 @@ class UserRepository(IUserRepository):
         first_name: str,
         last_name: str,
         email: str,
-        rotation_city_id: int
+        rotation_city_id: int,
+        profile_picture: Optional[str] = None
     ) -> User:
         """Create a new user in the database.
         
@@ -39,6 +40,7 @@ class UserRepository(IUserRepository):
             first_name: User's first name
             last_name: User's last name
             email: User's email address
+            profile_picture: Optional profile picture as base64 string
             rotation_city_id: ID of the user's rotation city
             
         Returns:
@@ -48,6 +50,7 @@ class UserRepository(IUserRepository):
             first_name=first_name,
             last_name=last_name,
             email=email,
+            profile_picture=profile_picture,
             rotation_city_id=rotation_city_id,
             is_verified=False,
             status=VerificationStatusEnum.PENDING.code
@@ -112,12 +115,11 @@ class UserRepository(IUserRepository):
         if not user:
             raise ValueError("User not found")
         
-        allowed_fields = ['first_name', 'last_name','rotation_city_id']
+        allowed_fields = ['first_name', 'last_name','rotation_city_id', 'profile_picture']
 
         for field in allowed_fields:
             if field in kwargs:
                 setattr(user, field, kwargs[field])
-
         
         db.session.commit()
         db.session.refresh(user)

--- a/backend/app/services/auth/registration_service.py
+++ b/backend/app/services/auth/registration_service.py
@@ -1,3 +1,4 @@
+from typing import Optional
 from app.repositories.implementations.user_repository import UserRepository
 from app.repositories.implementations.verification_code_repository import (
     VerificationCodeRepository
@@ -52,7 +53,8 @@ class RegistrationService:
         first_name: str,
         last_name: str,
         email: str,
-        rotation_city_id: int
+        rotation_city_id: int,
+        profile_picture: Optional[str] = None
     ) -> User:
         """Register a new user in the system.
         
@@ -64,6 +66,7 @@ class RegistrationService:
             last_name: User's last name
             email: User's email address
             rotation_city_id: ID of the user's current rotation city
+            profile_picture: Optional profile picture as base64 string
             
         Returns:
             Created or updated User object
@@ -87,7 +90,8 @@ class RegistrationService:
                     {
                         'first_name': first_name,
                         'last_name': last_name,
-                        'rotation_city_id': rotation_city_id
+                        'rotation_city_id': rotation_city_id,
+                        'profile_picture': profile_picture
                     }
                 )
                 return None
@@ -96,7 +100,8 @@ class RegistrationService:
             first_name=first_name,
             last_name=last_name,
             email=email,
-            rotation_city_id=rotation_city_id
+            rotation_city_id=rotation_city_id,
+            profile_picture=profile_picture
         )
 
         verification_code, code = (

--- a/backend/tests/fixtures/user_fixtures.py
+++ b/backend/tests/fixtures/user_fixtures.py
@@ -68,3 +68,20 @@ def verified_user(db_session, rotation_city):
     db_session.commit()
     db_session.refresh(user)
     return user
+
+@pytest.fixture
+def user_with_profile_picture(db_session, rotation_city):
+    """Create a test user with a profile picture."""
+    user = User(
+        first_name='Alice',
+        last_name='Williams',
+        email='alice@example.com',
+        rotation_city_id=rotation_city.city_id,
+        is_verified=False,
+        status=VerificationStatusEnum.PENDING.code,
+        profile_picture='data:image/png;base64,TESTBASE64DATA'
+    )
+    db_session.add(user)
+    db_session.commit()
+    db_session.refresh(user)
+    return user


### PR DESCRIPTION
* **user.py**: Added `profile_picture: Text` field .
* **user_schema.py**: Introduced `profile_picture` field.
* **user_repository.py**: Enabled `profile_picture` in create/update functions.
* **user_repository_interface.py**: Updated `create_user` signature to accept optional `profile_picture`.
* **test_user_profile_picture.py**: Added tests for profile picture.
