### PR TITLE
Add a refreshAccessToken helper

### DIFF
--- a/frontend/src/api/index.js
+++ b/frontend/src/api/index.js
@@ -1,4 +1,9 @@
-import { getAccessToken, clearTokens } from '../features/auth/services/authservice.js'
+// api/index.js
+import { 
+  getAccessToken, 
+  clearTokens,
+  refreshAccessToken,
+} from '../features/auth/services/authservice.js'
 
 // In production, VITE_API_URL should be set to the backend URL (e.g., https://rotation-ready-api.onrender.com)
 // In development, we use Vite's proxy which forwards /api to localhost:5000
@@ -10,48 +15,65 @@ const commonHeaders = {
   "Content-Type": "application/json",
 }
 
+// Reuse apiFetch behavior for auth check
 export const checkAuth = async () => {
   try {
-    const token = getAccessToken()
-    if (!token) return false
-    
-    const response = await fetch(`${API_BASE_URL}/user/me`, {
-      headers: {
-        'Authorization': `Bearer ${token}`
-      }
-    })
-    
-    if (response.status === 401) {
-      clearTokens()
-      return false
-    }
-    
-    return response.ok 
+    await apiFetch('/user/me')
+    return true
   } catch {
     return false
   }
 }
 
 export const apiFetch = async (endpoint, options = {}) => {
-  const token = getAccessToken()
-  
-  const response = await fetch(`${API_BASE_URL}${endpoint}`, {
-    ...options,
-    headers: {
-      ...commonHeaders,
-      ...(token && { 'Authorization': `Bearer ${token}` }),
-      ...options.headers,
-    },
+  const buildHeaders = (token, extraHeaders = {}) => ({
+    ...commonHeaders,
+    ...(token && { 'Authorization': `Bearer ${token}` }),
+    ...extraHeaders,
   })
 
-  if (!response.ok) {
-    const data = await response.json()
-    
-    if (response.status === 401) {
-      clearTokens()
-      window.location.href = '/login' 
+  let token = getAccessToken()
+
+  let response = await fetch(`${API_BASE_URL}${endpoint}`, {
+    ...options,
+    headers: buildHeaders(token, options.headers),
+  })
+
+  // Handle unauthorized / expired token
+  if (response.status === 401) {
+    let errorData = {}
+    try {
+      errorData = await response.json()
+    } catch {
+      errorData = {}
     }
-    
+
+    // If the access token is expired, try to refresh and retry once
+    if (errorData.message === 'Token has expired.') {
+      const newToken = await refreshAccessToken()
+      if (newToken) {
+        token = newToken
+        response = await fetch(`${API_BASE_URL}${endpoint}`, {
+          ...options,
+          headers: buildHeaders(token, options.headers),
+        })
+
+        if (response.ok) {
+          return response.json()
+        }
+
+        // If retry still fails, fall through to logout / error handling
+      }
+    }
+
+    // If refresh failed or token invalid for another reason
+    clearTokens()
+    window.location.href = '/login'
+    throw new Error(errorData.message || "Request failed")
+  }
+
+  if (!response.ok) {
+    const data = await response.json().catch(() => ({}))
     throw new Error(data.message || "Request failed")
   }
 

--- a/frontend/src/features/auth/services/authservice.js
+++ b/frontend/src/features/auth/services/authservice.js
@@ -1,4 +1,5 @@
-import { apiFetch } from "../../../api/index.js"
+// authservice.js
+import { apiFetch, API_BASE_URL } from "../../../api/index.js"
 
 const AUTH_PREFIX = "/auth"
 
@@ -13,6 +14,40 @@ export const getRefreshToken = () => localStorage.getItem('refresh_token')
 export const clearTokens = () => {
   localStorage.removeItem('access_token')
   localStorage.removeItem('refresh_token')
+}
+
+// NEW: refresh access token using the refresh token
+export const refreshAccessToken = async () => {
+  const refreshToken = getRefreshToken()
+  if (!refreshToken) {
+    clearTokens()
+    return null
+  }
+
+  const response = await fetch(`${API_BASE_URL}/auth/refresh`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "Authorization": `Bearer ${refreshToken}`,
+    },
+  })
+
+  if (!response.ok) {
+    clearTokens()
+    return null
+  }
+
+  const data = await response.json()
+  const newAccessToken = data.access_token
+
+  if (!newAccessToken) {
+    clearTokens()
+    return null
+  }
+
+  // Keep existing refresh token, just update access
+  localStorage.setItem('access_token', newAccessToken)
+  return newAccessToken
 }
 
 export const authService = {


### PR DESCRIPTION
**Concise PR Description:**

* **api/index.js**: Refactored `apiFetch` to centralize header building, added automatic access-token refresh on 401 (expired token), and retry logic before logout. Simplified `checkAuth` to rely on shared fetch behavior.
* **authservice.js**: Added `refreshAccessToken` to obtain a new access token using the refresh token and persist it. Updated imports to support refresh flow.
* **Auth flow improvement**: Prevents unnecessary logouts by refreshing expired tokens and retrying failed requests once before clearing tokens and redirecting to login.
